### PR TITLE
ParamType method in Flag.cs

### DIFF
--- a/nap/Flag.cs
+++ b/nap/Flag.cs
@@ -21,7 +21,6 @@ namespace nap
         			break;
         		default:
         			throw new Exception("Please Specify a valid Flag. or pass -help for options");
-        			break;
         	}
         }
     }

--- a/nap/Flag.cs
+++ b/nap/Flag.cs
@@ -1,7 +1,28 @@
+using System;
+
 namespace nap
 {
     public class Flag
     {
-        
+        public static void ParamType(string[] args)
+        {
+        	string flag = args[0];
+
+        	switch(flag)
+        	{
+        		case "-pl":
+        			Console.WriteLine("call play and pass file argument");
+        			break;
+        		case "-st":
+        			Console.WriteLine("call stop and pass file argument");
+        			break;
+        		case "-help":
+        			Console.WriteLine("eventually list all the help options");
+        			break;
+        		default:
+        			throw new Exception("Please Specify a valid Flag. or pass -help for options");
+        			break;
+        	}
+        }
     }
 }

--- a/nap/Program.cs
+++ b/nap/Program.cs
@@ -6,17 +6,13 @@ namespace nap
     {
         private static void Main(string[] args)
         {
-            /* db:
-            * I'll clean this up a bit more
-            * Shouldn't have this much going on in the main function
-            */
+            Flag.ParamType(args);
 
             object configObj = Config.ReadConfig();
             string configStr = "";
             configStr += configObj;
-            string mp3Path = configStr + "/sample.mp3";
-            Console.WriteLine(mp3Path);
         }
+
         public static string Test()
         {
             return "Hello World!";


### PR DESCRIPTION
Added the ParamType method in the Flag.cs file, which is invoked in the Program.cs file to catch the arguments when the program is run for "-pl" (play), "-st" (stop), "-help" (help), and a c default statement which throws an error when no arguments or file directory is passed.

To Test:
~ pull this branch
~ compile and run
~ it should error out if you dont pass any arguments